### PR TITLE
Fix generator exceptions

### DIFF
--- a/ShapeKeys/SliderImpactGenerator.py
+++ b/ShapeKeys/SliderImpactGenerator.py
@@ -70,10 +70,27 @@ def main():
 
     # Define the folder path
     folder_path = os.getcwd()
-
+    file_list = []
+    charaname =''
     # Get Character's Name from Ini's File Name
-    file = glob.glob('*.ini')[0]
-    charaname = file[:-4]
+    try:
+        for file in os.listdir(folder_path):
+            if file.lower().startswith('disabled'):
+                pass
+            elif file.endswith('.ini'):
+                file_list.append(file)
+        if len(file_list) == 0:
+            print('No enabled mod')
+            return
+        elif len(file_list) == 1:
+            file = file_list[0]
+        else:
+            print('Multiple enabled mods')
+            return
+        charaname = file[:-4]
+        print('character: '+charaname)
+    except FileExistsError:
+        print('No enabled mod')
 
     # Iterate over the files in the folder
     baseposition = [filename for filename in os.listdir(folder_path) if "base" in filename.lower() 


### PR DESCRIPTION
previously it would fail if a disabled backup ini or multiple ini files existed. quick and easy fix here to take the ini if and only if its the only enabled file. Also uses try catch now just in case. We love try catch, please use and abuse try catch even if you don't think you need it